### PR TITLE
Fix Mailchimp popup: use embedded React modal with auto-open and PDF download

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/all_logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agentic Learning Labs</title>
-    <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/9840fbf977e70b072bf8c81c8/7b8daa8856fadf3e4d259f048.js")</script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import ScrollLink from './components/ScrollLink'
 import CustomerExperience from './pages/CustomerExperience'
 import SalesMarketing from './pages/SalesMarketing'
 import InquiryModal from './components/InquiryModal'
+import PromptKitModal from './components/PromptKitModal'
 import LearnMore from './pages/LearnMore'
 import HealthCheck from './pages/HealthCheck'
 import { initGA, trackPageView, trackCampaignData } from './lib/analytics'
@@ -58,8 +59,9 @@ function App() {
       </Routes>
       <PrereqModal />
       <InquiryModal />
+      <PromptKitModal />
     </>
   )
 }
-3
+
 export default App

--- a/frontend/src/components/PromptKitModal.jsx
+++ b/frontend/src/components/PromptKitModal.jsx
@@ -16,7 +16,7 @@ const PromptKitModal = () => {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const handleClose = () => {
-    localStorage.setItem('promptKitDismissed', 'true');
+    localStorage.setItem('promptKitDismissed', String(Date.now()));
     closeModal();
   };
 
@@ -30,11 +30,15 @@ const PromptKitModal = () => {
         'email': email,
         'message': `[AI Prompt Kit Request] ${message}`,
       });
-      setIsSubmitted(true);
-      localStorage.setItem('promptKitDismissed', 'true');
     } catch (error) {
       console.error(error);
     }
+    setIsSubmitted(true);
+    localStorage.setItem('promptKitDismissed', String(Date.now()));
+    const link = document.createElement('a');
+    link.href = '/AI_Prompt_Playbook_2026.pdf';
+    link.download = 'AI_Prompt_Playbook_2026.pdf';
+    link.click();
     setIsLoading(false);
   };
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { Analytics } from "@vercel/analytics/react"
 import { PrereqModalProvider } from './context/PrereqModalContext.jsx'
 import { InquiryModalProvider } from './context/InquiryModalContext.jsx'
+import { PromptKitModalProvider } from './context/PromptKitModalContext.jsx'
 import App from './App.jsx'
 import './index.css'
 
@@ -13,8 +14,10 @@ createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <PrereqModalProvider>
         <InquiryModalProvider>
-          <App />
-          <Analytics />
+          <PromptKitModalProvider>
+            <App />
+            <Analytics />
+          </PromptKitModalProvider>
         </InquiryModalProvider>
       </PrereqModalProvider>
     </BrowserRouter>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { usePromptKitModal } from '../context/PromptKitModalContext.jsx';
 
 import Header from '../components/Header';
@@ -24,6 +24,15 @@ import ontario from '../assets/images/ontario.png';
 
 const Home = () => {
   const { openModal: openPromptKitModal } = usePromptKitModal();
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem('promptKitDismissed');
+    const showPopup = !dismissed || (Date.now() - Number(dismissed)) > 24 * 60 * 60 * 1000;
+    if (showPopup) {
+      const timer = setTimeout(() => openPromptKitModal(), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, []);
 
   const sectionWrapper = "w-full mx-auto px-6 lg:px-16";
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { usePromptKitModal } from '../context/PromptKitModalContext.jsx';
 
 import Header from '../components/Header';
 import HeaderLogo from '../components/HeaderLogo';
@@ -22,12 +23,7 @@ import ontario from '../assets/images/ontario.png';
 
 
 const Home = () => {
-
-  const openMailchimpPopup = () => {
-    document.cookie = 'MCPopupClosed=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-    document.cookie = 'MCPopupSubscribed=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-    window.location.reload();
-  };
+  const { openModal: openPromptKitModal } = usePromptKitModal();
 
   const sectionWrapper = "w-full mx-auto px-6 lg:px-16";
 
@@ -112,7 +108,7 @@ const Home = () => {
                 <h3 className="[font-family:'Unageo'] text-lg">Learn more</h3>
               </a>
               <button
-                onClick={openMailchimpPopup}
+                onClick={openPromptKitModal}
                 className="w-[226px] h-[40px] flex items-center justify-center text-black hover:text-white bg-brand_yellow hover:bg-brand_black rounded-3xl transition-all duration-200 ease-in-out"
               >
                 <h3 className="[font-family:'Unageo'] text-sm">Free AI Prompt Kit</h3>


### PR DESCRIPTION
## Summary
- Remove broken Mailchimp connected-site script (consent gate was blocking popup in SPA)
- Restore `PromptKitModal` and context provider for in-app lead capture
- Popup auto-opens after 2s on page load for new visitors (24h cooldown via localStorage timestamp)
- "Free AI Prompt Kit" button still opens modal manually
- PDF auto-downloads on form submit regardless of backend API availability
- Fix stray character in App.jsx

## Test plan
- [ ] Visit home page — popup appears after ~2 seconds
- [ ] Dismiss popup, refresh — popup does not reappear (within 24h)
- [ ] Clear localStorage, refresh — popup reappears
- [ ] Click "Free AI Prompt Kit" button — popup opens immediately
- [ ] Submit form — PDF downloads automatically, success screen shown
- [ ] Download button on success screen works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)